### PR TITLE
Switched version check to 1.9 from 1.10

### DIFF
--- a/src/me/mrCookieSlime/CSCoreLibPlugin/general/Chat/TellRawMessage.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/general/Chat/TellRawMessage.java
@@ -28,7 +28,7 @@ public class TellRawMessage {
 			constructor = ReflectionUtils.getClass("PacketPlayOutChat").getConstructor(ReflectionUtils.getClass("IChatBaseComponent"));
 			serializer = ReflectionUtils.tryClass(PackageName.NMS, "ChatSerializer", "IChatBaseComponent$ChatSerializer");
 			
-			if (ReflectionUtils.getVersion().startsWith("v1_10_")) {
+			if (ReflectionUtils.getVersion().startsWith("v1_9_")) {
 				method = ReflectionUtils.tryMethod(serializer, new String[] {"b", "a"}, String.class);
 			}
 			else {


### PR DESCRIPTION
having 1.9 versions do the tryMethod "a" then "b" would still return a valid function but it would not be the correct method to use for 1.9.  "b" needs to be sent first.
