### PR TITLE
Fix PlotSquaredProtectionModule

### DIFF
--- a/src/me/mrCookieSlime/CSCoreLibPlugin/protection/modules/PlotSquaredProtectionModule.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/protection/modules/PlotSquaredProtectionModule.java
@@ -4,25 +4,27 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
 import com.intellectualcrafters.plot.config.C;
+import com.intellectualcrafters.plot.object.Location;
+import com.intellectualcrafters.plot.object.Plot;
 import com.intellectualcrafters.plot.object.PlotPlayer;
 import com.intellectualcrafters.plot.util.Permissions;
+
 import me.mrCookieSlime.CSCoreLibPlugin.protection.ProtectionModule;
 
 
 public class PlotSquaredProtectionModule implements ProtectionModule {
-	
+	private boolean hasAccess(Player player, Block b) {
+		Plot plot = new Location(b.getWorld().getName(), b.getX(), b.getY(), b.getZ()).getOwnedPlot();
+		return plot == null || plot.isAdded(player.getUniqueId());
+	}
 	@Override
 	public boolean canBuild(Player player, Block b) {
-		return Permissions.hasPermission(PlotPlayer.wrap(player), C.PERMISSION_ADMIN_BUILD_UNOWNED);
+		return hasAccess(player, b) || Permissions.hasPermission(PlotPlayer.wrap(player), C.PERMISSION_ADMIN_BUILD_UNOWNED);
 	}
 	
 	@Override
 	public boolean canAccessChest(Player player, Block b) {
-		PlotPlayer pp = PlotPlayer.wrap(player);
-		if(pp.getCurrentPlot().isAdded(pp.getUUID()) || Permissions.hasPermission(pp, C.PERMISSION_ADMIN_INTERACT_UNOWNED)) {
-			return true;
-		}
-		return false;
+		return hasAccess(player,b) || Permissions.hasPermission(PlotPlayer.wrap(player), C.PERMISSION_ADMIN_INTERACT_UNOWNED);
 	}
 
 	@Override


### PR DESCRIPTION
This fixes a couple of issues with the old version. 

1. A NullPointerException when the player wasn't in a plot. 
2. canBuild only allowing players with admin permission to build
3. The access check was performed based on where the player was standing instead of which block they were changing.