### PR TITLE
Signal with BlockBreakEvent.setDropItems(false)

### DIFF
--- a/src/me/mrCookieSlime/CSCoreLibPlugin/general/Block/BlockBreaker.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/general/Block/BlockBreaker.java
@@ -35,6 +35,7 @@ public class BlockBreaker {
 		
 		if (check) {
 			BlockBreakEvent event = new BlockBreakEvent(b, p);
+			event.setDropItems(false);
 			Bukkit.getServer().getPluginManager().callEvent(event);
 			allowed = !event.isCancelled();
 		}


### PR DESCRIPTION
I have another plugin that allows players to place logs that have bark on all sides. It drops a custom item in its BlockBreakEvent handler. When SlimeFun's saw mill is used on one of these logs, both the 8 planks and the custom item are dropped. With this change, the log plugin will be able to use isDropItems to decide whether or not to drop its custom item.

Thanks.