### PR TITLE
Updated Wilderness' ID

### DIFF
--- a/src/me/mrCookieSlime/CSCoreLibPlugin/protection/modules/FactionsUUIDProtectionModule.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/protection/modules/FactionsUUIDProtectionModule.java
@@ -28,7 +28,7 @@ public class FactionsUUIDProtectionModule implements ProtectionModule {
 		Faction faction = Board.getInstance().getFactionAt(fLoc);
 		FPlayer fPlayer = FPlayers.getInstance().getByPlayer(player);
 		
-		if (faction != null && !faction.getId().equals("none")) {
+		if (faction != null && !faction.getId().equals("0")) {
 			if (!faction.getId().equals(fPlayer.getFaction().getId())) return true;
 		}
 		return false;


### PR DESCRIPTION
FactionsUUID uses "0" instead of "none" for Wilderness zone.
Didn't know this since I have only two global factions that own the whole territory.
I tested it on the clean server. It should work now as supposed.