### PR TITLE
Updated plugin api-version to 1.13

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -5,6 +5,8 @@ website: http://thebusybiscuit.github.io/
 
 main: me.mrCookieSlime.CSCoreLibPlugin.CSCoreLib
 
+api-version: 1.13
+
 commands:
   cs_triggerinterface:
     description: Background Command


### PR DESCRIPTION
As of 1.13 [spigot requires the api version to be set](https://www.spigotmc.org/wiki/plugin-yml/) (e.g. for the new Materials)
