### PR TITLE
Updated ASkyBlock version to 3.0.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>com.wasteofplastic</groupId>
             <artifactId>askyblock</artifactId>
-            <version>3.0.8.2</version>
+            <version>3.0.9.4</version>
         </dependency>
         <dependency>
             <groupId>com.github.dmulloy2.LWC</groupId>


### PR DESCRIPTION
The ASkyBlock version used in the dependencies is out of date.