### PR TITLE
Update Towny to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>com.github.LlmDl</groupId>
             <artifactId>Towny</artifactId>
-            <version>2aeeb30903</version>
+            <version>1b86d017c5</version>
         </dependency>
         <dependency>
             <groupId>com.github.fubira</groupId>

--- a/src/me/mrCookieSlime/CSCoreLibPlugin/protection/modules/TownyProtectionModule.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/protection/modules/TownyProtectionModule.java
@@ -15,12 +15,12 @@ public class TownyProtectionModule implements ProtectionModule {
     public boolean canBuild(Player player, Block b) {
     	//ActionType is DESTROY because other plugins mostly use canBuild function to check if the player has permission to destroy block.
     	//TODO: Split canBuild() into 2 functions (canBuild and canDestroy).
-        return PlayerCacheUtil.getCachePermission(player, b.getLocation(), BukkitTools.getTypeId(b), BukkitTools.getData(b), ActionType.DESTROY);
+        return PlayerCacheUtil.getCachePermission(player, b.getLocation(), b.getType(), ActionType.DESTROY);
     }
 
     @Override
     public boolean canAccessChest(Player player, Block b) {
-        return PlayerCacheUtil.getCachePermission(player, b.getLocation(), BukkitTools.getTypeId(b), BukkitTools.getData(b), ActionType.SWITCH);
+        return PlayerCacheUtil.getCachePermission(player, b.getLocation(), b.getType(), ActionType.SWITCH);
     }
 
     @Override


### PR DESCRIPTION
These commits update the referenced Towny library to the [latest project version](https://github.com/TownyAdvanced/Towny/commit/1b86d017c508e74b4a8383f60ee9d9d5aa1c18b7) and rewrites calls to replace a [deprecated/removed](https://github.com/TownyAdvanced/Towny/commit/583c3303#diff-65c47dc1e662a52bec99721374fe7c7c) version of Towny's `PlayerCacheUtil.getCachePermission()` method.

Should fix issues like the one mentioned in #68:

```
java.lang.NoSuchMethodError: com.palmergames.bukkit.towny.utils.PlayerCacheUtil.getCachePermission(Lorg/bukkit/entity/Player;Lorg/bukkit/Location;Ljava/lang/Integer;BLcom/palmergames/bukkit/towny/object/TownyPermission$ActionType;)Z
```

And issues that appeared as of 1.14 on our own servers because of the use of deprecated methods:

```
Could not pass event BlockBreakEvent to Slimefun vDEV - 99 (git 6df3f8df)
...
java.lang.IllegalArgumentException: Cannot get ID of Modern Material
   at org.apache.commons.lang.Validate.isTrue(Validate.java:136)
   at org.bukkit.Material.getId(Material.java:3319)
   at com.palmergames.bukkit.util.BukkitTools.getTypeId(BukkitTools.java:186)
   at me.mrCookieSlime.CSCoreLibPlugin.protection.modules.TownyProtectionModule.canBuild(TownyProtectionModule.java:18)
   ...
```
```
Could not pass event ItemUseEvent to Slimefun vDEV - 99 (git 6df3f8df)
...
java.lang.IllegalArgumentException: Cannot get ID of Modern Material
   at org.apache.commons.lang.Validate.isTrue(Validate.java:136)
   at org.bukkit.Material.getId(Material.java:3302)
   at com.palmergames.bukkit.util.BukkitTools.getTypeId(BukkitTools.java:192)
   at me.mrCookieSlime.CSCoreLibPlugin.protection.modules.TownyProtectionModule.canAccessChest(TownyProtectionModule.java:23)
   ...
```
In addition to spamming the console, these issues would prevent most tools (tested breaking with Explosive Pickaxe, opening with Crucible) from working properly or being used because of the broken permission checks.

Tested with:
* CraftBukkit version git-Spigot-03bd4b0-342194e (MC: 1.14.1) (Implementing API version 1.14.1-R0.1-SNAPSHOT)
* Slimefun vDEV - 99 (git 6df3f8df)
* Towny 0.93.1.0 (git 1b86d017c5)