### PR TITLE
Remove hard-coding from MaterialHelper

### DIFF
--- a/src/me/mrCookieSlime/CSCoreLibPlugin/CSCoreLib.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/CSCoreLib.java
@@ -1,6 +1,7 @@
 package me.mrCookieSlime.CSCoreLibPlugin;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
@@ -8,6 +9,7 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import me.mrCookieSlime.CSCoreLibPlugin.compatibility.MaterialHelper;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Marker;
@@ -116,6 +118,8 @@ public class CSCoreLib extends JavaPlugin {
 			}
 			
 		});
+
+		System.out.println(Arrays.toString(MaterialHelper.WoolColours));
 	}
 	
 	public void filterLog(String pattern) {

--- a/src/me/mrCookieSlime/CSCoreLibPlugin/CSCoreLib.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/CSCoreLib.java
@@ -1,7 +1,6 @@
 package me.mrCookieSlime.CSCoreLibPlugin;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
@@ -9,7 +8,6 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import me.mrCookieSlime.CSCoreLibPlugin.compatibility.MaterialHelper;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Marker;

--- a/src/me/mrCookieSlime/CSCoreLibPlugin/CSCoreLib.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/CSCoreLib.java
@@ -47,7 +47,7 @@ public class CSCoreLib extends JavaPlugin {
 	
 	private ProtectionManager manager;
 	
-	private Set<Pattern> log_patterns = new HashSet<Pattern>();
+	private Set<Pattern> log_patterns = new HashSet<>();
 	
 	@Override
 	public void onEnable() {
@@ -111,15 +111,8 @@ public class CSCoreLib extends JavaPlugin {
 		
 		filterLog("([A-Za-z0-9_]{3,16}) issued server command: /cs_triggerinterface (.{0,})");
 		
-		getServer().getScheduler().scheduleSyncDelayedTask(instance, new Runnable() {
-			
-			public void run() {
-				manager = new ProtectionManager(instance);
-			}
-			
-		});
-
-		System.out.println(Arrays.toString(MaterialHelper.WoolColours));
+		getServer().getScheduler().scheduleSyncDelayedTask(instance, () ->
+			manager = new ProtectionManager(instance));
 	}
 	
 	public void filterLog(String pattern) {

--- a/src/me/mrCookieSlime/CSCoreLibPlugin/compatibility/MaterialHelper.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/compatibility/MaterialHelper.java
@@ -30,24 +30,15 @@ public class MaterialHelper {
     }
 
     public static Material getSaplingFromLog(Material log) {
-        switch (log) {
-            case OAK_LOG:
-                return Material.OAK_SAPLING;
-            case SPRUCE_LOG:
-                return Material.SPRUCE_SAPLING;
-            case BIRCH_LOG:
-                return Material.BIRCH_SAPLING;
-            case JUNGLE_LOG:
-                return Material.JUNGLE_SAPLING;
-            case ACACIA_LOG:
-                return Material.ACACIA_SAPLING;
-            case DARK_OAK_LOG:
-                return Material.DARK_OAK_SAPLING;
-            default:
-                break;
-        }
+        if (!isLog(log))
+            return Material.AIR;
 
-        return Material.OAK_SAPLING;
+        String type = log.name().substring(0, log.name().lastIndexOf('_'));
+        try {
+            return Material.valueOf(type + "_SAPLING");
+        }catch (IllegalArgumentException ignored) {
+            return Material.AIR;
+        }
     }
 
     public static Material getWoodFromLog(Material log) {
@@ -57,7 +48,7 @@ public class MaterialHelper {
         String type = log.name().substring(0, log.name().lastIndexOf('_'));
         try {
             return Material.valueOf(type + "_PLANKS");
-        }catch (IllegalArgumentException ignored) {
+        } catch (IllegalArgumentException ignored) {
             return Material.AIR;
         }
     }

--- a/src/me/mrCookieSlime/CSCoreLibPlugin/compatibility/MaterialHelper.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/compatibility/MaterialHelper.java
@@ -2,100 +2,73 @@ package me.mrCookieSlime.CSCoreLibPlugin.compatibility;
 
 import org.bukkit.Material;
 
-/**
- */
+import java.util.Arrays;
+
 public class MaterialHelper {
 
+    public static final Material[] WoolColours;
+    public static final Material[] StainedGlassColours;
+    public static final Material[] StainedGlassPaneColours;
+    public static final Material[] TerracottaColours;
+    public static final Material[] GlazedTerracottaColours;
 
-	public static Material getSaplingFromLog(Material log) {
-		switch (log) {
-			case OAK_LOG:
-				return Material.OAK_SAPLING;
-			case SPRUCE_LOG:
-				return Material.SPRUCE_SAPLING;
-			case BIRCH_LOG:
-				return Material.BIRCH_SAPLING;
-			case JUNGLE_LOG:
-				return Material.JUNGLE_SAPLING;
-			case ACACIA_LOG:
-				return Material.ACACIA_SAPLING;
-			case DARK_OAK_LOG:
-				return Material.DARK_OAK_SAPLING;
-			default:
-				break;
-		}
-		
-		return Material.OAK_SAPLING;
-	}
+    static {
+        WoolColours = Arrays.stream(Material.values()).filter(MaterialHelper::isWool)
+            .toArray(Material[]::new);
 
+        StainedGlassColours = Arrays.stream(Material.values()).filter(MaterialHelper::isStainedGlass)
+            .toArray(Material[]::new);
 
-    public static Material getWoodFromLog(Material log) {
+        StainedGlassPaneColours = Arrays.stream(Material.values()).filter(MaterialHelper::isStainedGlassPane)
+            .toArray(Material[]::new);
+
+        TerracottaColours = Arrays.stream(Material.values()).filter(MaterialHelper::isTerracotta)
+            .toArray(Material[]::new);
+
+        GlazedTerracottaColours = Arrays.stream(Material.values()).filter(MaterialHelper::isGlazedTerracotta)
+            .toArray(Material[]::new);
+    }
+
+    public static Material getSaplingFromLog(Material log) {
         switch (log) {
             case OAK_LOG:
-                return Material.OAK_PLANKS;
+                return Material.OAK_SAPLING;
             case SPRUCE_LOG:
-                return Material.SPRUCE_PLANKS;
+                return Material.SPRUCE_SAPLING;
             case BIRCH_LOG:
-                return Material.BIRCH_PLANKS;
+                return Material.BIRCH_SAPLING;
             case JUNGLE_LOG:
-                return Material.JUNGLE_PLANKS;
+                return Material.JUNGLE_SAPLING;
             case ACACIA_LOG:
-                return Material.ACACIA_PLANKS;
+                return Material.ACACIA_SAPLING;
             case DARK_OAK_LOG:
-                return Material.DARK_OAK_PLANKS;
+                return Material.DARK_OAK_SAPLING;
             default:
-            	break;
+                break;
         }
-        
-        return Material.OAK_WOOD;
+
+        return Material.OAK_SAPLING;
+    }
+
+    public static Material getWoodFromLog(Material log) {
+        if (!isLog(log))
+            return Material.AIR;
+
+        String type = log.name().substring(0, log.name().lastIndexOf('_'));
+        try {
+            return Material.valueOf(type + "_PLANKS");
+        }catch (IllegalArgumentException ignored) {
+            return Material.AIR;
+        }
     }
 
     public static boolean isLog(Material log) {
-        switch (log) {
-            case OAK_LOG:
-            case SPRUCE_LOG:
-            case BIRCH_LOG:
-            case JUNGLE_LOG:
-            case ACACIA_LOG:
-            case DARK_OAK_LOG:
-                return true;
-            default:
-            	return false;
-        }
+        return log.name().endsWith("_LOG");
     }
 
     public static boolean isLeavesBlock(Material leaves) {
-        switch (leaves) {
-            case OAK_LEAVES:
-            case SPRUCE_LEAVES:
-            case BIRCH_LEAVES:
-            case JUNGLE_LEAVES:
-            case ACACIA_LEAVES:
-            case DARK_OAK_LEAVES:
-                return true;
-            default:
-            	return false;
-        }
+        return leaves.name().endsWith("_LEAVES");
     }
-
-    public static final Material[] WoolColours = {
-            Material.WHITE_WOOL,
-            Material.ORANGE_WOOL,
-            Material.MAGENTA_WOOL,
-            Material.LIGHT_BLUE_WOOL,
-            Material.YELLOW_WOOL,
-            Material.LIME_WOOL,
-            Material.PINK_WOOL,
-            Material.GRAY_WOOL,
-            Material.LIGHT_GRAY_WOOL,
-            Material.CYAN_WOOL,
-            Material.PURPLE_WOOL,
-            Material.BLUE_WOOL,
-            Material.BROWN_WOOL,
-            Material.GREEN_WOOL,
-            Material.RED_WOOL,
-            Material.BLACK_WOOL
-    };
 
     public static boolean isWool(Material material) {
         for (Material mat : WoolColours)
@@ -103,104 +76,19 @@ public class MaterialHelper {
         return false;
     }
 
-    public static final Material[] StainedGlassColours = {
-            Material.WHITE_STAINED_GLASS,
-            Material.ORANGE_STAINED_GLASS,
-            Material.MAGENTA_STAINED_GLASS,
-            Material.LIGHT_BLUE_STAINED_GLASS,
-            Material.YELLOW_STAINED_GLASS,
-            Material.LIME_STAINED_GLASS,
-            Material.PINK_STAINED_GLASS,
-            Material.GRAY_STAINED_GLASS,
-            Material.LIGHT_GRAY_STAINED_GLASS,
-            Material.CYAN_STAINED_GLASS,
-            Material.PURPLE_STAINED_GLASS,
-            Material.BLUE_STAINED_GLASS,
-            Material.BROWN_STAINED_GLASS,
-            Material.GREEN_STAINED_GLASS,
-            Material.RED_STAINED_GLASS,
-            Material.BLACK_STAINED_GLASS
-    };
-
     public static boolean isStainedGlass(Material material) {
-        for (Material mat : StainedGlassColours)
-            if (mat == material) return true;
-        return false;
+        return material.name().endsWith("_STAINED_GLASS");
     }
-
-    public static final Material[] StainedGlassPaneColours = {
-            Material.WHITE_STAINED_GLASS_PANE,
-            Material.ORANGE_STAINED_GLASS_PANE,
-            Material.MAGENTA_STAINED_GLASS_PANE,
-            Material.LIGHT_BLUE_STAINED_GLASS_PANE,
-            Material.YELLOW_STAINED_GLASS_PANE,
-            Material.LIME_STAINED_GLASS_PANE,
-            Material.PINK_STAINED_GLASS_PANE,
-            Material.GRAY_STAINED_GLASS_PANE,
-            Material.LIGHT_GRAY_STAINED_GLASS_PANE,
-            Material.CYAN_STAINED_GLASS_PANE,
-            Material.PURPLE_STAINED_GLASS_PANE,
-            Material.BLUE_STAINED_GLASS_PANE,
-            Material.BROWN_STAINED_GLASS_PANE,
-            Material.GREEN_STAINED_GLASS_PANE,
-            Material.RED_STAINED_GLASS_PANE,
-            Material.BLACK_STAINED_GLASS_PANE
-    };
 
     public static boolean isStainedGlassPane(Material material) {
-        for (Material mat : StainedGlassPaneColours)
-            if (mat == material) return true;
-        return false;
+        return material.name().endsWith("_STAINED_GLASS_PANE");
     }
 
-    public static final Material[] TerracottaColours = {
-            Material.WHITE_TERRACOTTA,
-            Material.ORANGE_TERRACOTTA,
-            Material.MAGENTA_TERRACOTTA,
-            Material.LIGHT_BLUE_TERRACOTTA,
-            Material.YELLOW_TERRACOTTA,
-            Material.LIME_TERRACOTTA,
-            Material.PINK_TERRACOTTA,
-            Material.GRAY_TERRACOTTA,
-            Material.LIGHT_GRAY_TERRACOTTA,
-            Material.CYAN_TERRACOTTA,
-            Material.PURPLE_TERRACOTTA,
-            Material.BLUE_TERRACOTTA,
-            Material.BROWN_TERRACOTTA,
-            Material.GREEN_TERRACOTTA,
-            Material.RED_TERRACOTTA,
-            Material.BLACK_TERRACOTTA
-    };
-
-     public static boolean isTerracotta(Material material) {
-        for (Material mat : TerracottaColours)
-            if (mat == material) return true;
-        return false;
-    }
-    
-    public static final Material[] GlazedTerracottaColours = {
-            Material.WHITE_GLAZED_TERRACOTTA,
-            Material.ORANGE_GLAZED_TERRACOTTA,
-            Material.MAGENTA_GLAZED_TERRACOTTA,
-            Material.LIGHT_BLUE_GLAZED_TERRACOTTA,
-            Material.YELLOW_GLAZED_TERRACOTTA,
-            Material.LIME_GLAZED_TERRACOTTA,
-            Material.PINK_GLAZED_TERRACOTTA,
-            Material.GRAY_GLAZED_TERRACOTTA,
-            Material.LIGHT_GRAY_GLAZED_TERRACOTTA,
-            Material.CYAN_GLAZED_TERRACOTTA,
-            Material.PURPLE_GLAZED_TERRACOTTA,
-            Material.BLUE_GLAZED_TERRACOTTA,
-            Material.BROWN_GLAZED_TERRACOTTA,
-            Material.GREEN_GLAZED_TERRACOTTA,
-            Material.RED_GLAZED_TERRACOTTA,
-            Material.BLACK_GLAZED_TERRACOTTA
-    };
-
-     public static boolean isGlazedTerracotta(Material material) {
-        for (Material mat : GlazedTerracottaColours)
-            if (mat == material) return true;
-        return false;
+    public static boolean isTerracotta(Material material) {
+        return material.name().endsWith("_TERRACOTTA");
     }
 
+    public static boolean isGlazedTerracotta(Material material) {
+        return material.name().endsWith("_GLAZED_TERRACOTTA");
+    }
 }

--- a/src/me/mrCookieSlime/CSCoreLibPlugin/compatibility/MaterialHelper.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/compatibility/MaterialHelper.java
@@ -62,9 +62,7 @@ public class MaterialHelper {
     }
 
     public static boolean isWool(Material material) {
-        for (Material mat : WoolColours)
-            if (mat == material) return true;
-        return false;
+        return material.name().endsWith("_WOOL");
     }
 
     public static boolean isStainedGlass(Material material) {


### PR DESCRIPTION
Make MaterialHelper checks now use the name to check if it's valid, alongside that the arrays are now initialised in a static block using the check helper functions.