### PR TITLE
Add support for FactionsUUID fork

### DIFF
--- a/src/me/mrCookieSlime/CSCoreLibPlugin/protection/ProtectionManager.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/protection/ProtectionManager.java
@@ -37,10 +37,12 @@ public class ProtectionManager {
 			registerNewModule("WorldGuard", new WorldGuardProtectionModule());
 		}
 		if (cscorelib.getServer().getPluginManager().isPluginEnabled("Factions")) {
-			if (cscorelib.getServer().getPluginManager().getPlugin("Factions") instanceof com.massivecraft.factions.P)
-				registerNewModule("Factions", new FactionsUUIDProtectionModule());
-			else
-				registerNewModule("Factions", new FactionsProtectionModule());
+			try {
+        Class.forName("com.massivecraft.factions.event.PowerLossEvent");
+        registerNewModule("Factions", new FactionsUUIDProtectionModule());
+      } catch (ClassNotFoundException e) {
+        registerNewModule("Factions", new FactionsProtectionModule());
+      }
 		}
 		if (cscorelib.getServer().getPluginManager().isPluginEnabled("Towny")) {
 			registerNewModule("Towny", new TownyProtectionModule());

--- a/src/me/mrCookieSlime/CSCoreLibPlugin/protection/ProtectionManager.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/protection/ProtectionManager.java
@@ -38,11 +38,11 @@ public class ProtectionManager {
 		}
 		if (cscorelib.getServer().getPluginManager().isPluginEnabled("Factions")) {
 			try {
-        Class.forName("com.massivecraft.factions.event.PowerLossEvent");
-        registerNewModule("Factions", new FactionsUUIDProtectionModule());
-      } catch (ClassNotFoundException e) {
-        registerNewModule("Factions", new FactionsProtectionModule());
-      }
+				Class.forName("com.massivecraft.factions.event.PowerLossEvent");
+				registerNewModule("Factions", new FactionsUUIDProtectionModule());
+			} catch (ClassNotFoundException e) {
+				registerNewModule("Factions", new FactionsProtectionModule());
+			}
 		}
 		if (cscorelib.getServer().getPluginManager().isPluginEnabled("Towny")) {
 			registerNewModule("Towny", new TownyProtectionModule());

--- a/src/me/mrCookieSlime/CSCoreLibPlugin/protection/ProtectionManager.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/protection/ProtectionManager.java
@@ -37,12 +37,10 @@ public class ProtectionManager {
 			registerNewModule("WorldGuard", new WorldGuardProtectionModule());
 		}
 		if (cscorelib.getServer().getPluginManager().isPluginEnabled("Factions")) {
-			try {
-				Class.forName("com.massivecraft.factions.event.PowerLossEvent");
-				registerNewModule("Factions", new FactionsUUIDProtectionModule());
-			} catch (ClassNotFoundException e) {
+			if (cscorelib.getServer().getPluginManager().getPlugin("Factions").getDescription().getDepend().contains("MassiveCore"))
 				registerNewModule("Factions", new FactionsProtectionModule());
-			}
+			else
+				registerNewModule("Factions", new FactionsUUIDProtectionModule());
 		}
 		if (cscorelib.getServer().getPluginManager().isPluginEnabled("Towny")) {
 			registerNewModule("Towny", new TownyProtectionModule());


### PR DESCRIPTION
FactionsUUID had a event called "PowerLossEvent", which can't be found on MassiveCraft's Factions
I used that to detect whether the plugin is FactionsUUID or not.

This also adds support for FactionsUUID fork (SavageFactions, SaberFactions, etc)

EDIT: I changed the code to check the description instead of the event because of not enough stability