### PR TITLE
Fix Base64 on Java 11

### DIFF
--- a/src/me/mrCookieSlime/CSCoreLibPlugin/java/Converter.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/java/Converter.java
@@ -1,13 +1,13 @@
 package me.mrCookieSlime.CSCoreLibPlugin.java;
 
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 public class Converter {
 	
 	public static String encode(EncodingType type, String string) {
 		switch (type) {
 		case BASE64: {
-			return DatatypeConverter.printBase64Binary(string.getBytes());
+			return new String(Base64.getEncoder().encode(string.getBytes()));
 		}
 		case BINARY: {
 			StringBuilder binary = new StringBuilder();
@@ -29,7 +29,7 @@ public class Converter {
 	public static String decode(EncodingType type, String string) {
 		switch (type) {
 		case BASE64: {
-			return new String(DatatypeConverter.parseBase64Binary(string));
+			return new String(Base64.getDecoder().decode(string));
 		}
 		case BINARY: {
 			StringBuilder text = new StringBuilder();

--- a/src/me/mrCookieSlime/CSCoreLibPlugin/java/Converter.java
+++ b/src/me/mrCookieSlime/CSCoreLibPlugin/java/Converter.java
@@ -7,7 +7,7 @@ public class Converter {
 	public static String encode(EncodingType type, String string) {
 		switch (type) {
 		case BASE64: {
-			return new String(Base64.getEncoder().encode(string.getBytes()));
+			return Base64.getEncoder().encodeToString(string.getBytes());
 		}
 		case BINARY: {
 			StringBuilder binary = new StringBuilder();


### PR DESCRIPTION
javax.xml.bind has been removed on Java 11
That causes some plugins like EmeraldEnchants being disabled when starting the server in Java 11.

This PR fixes it

